### PR TITLE
Provided Configuration by plist support

### DIFF
--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
@@ -18,6 +18,9 @@
 @protocol JSApplicationURLResourceOpeningDelegate;
 @protocol JSApplicationProtectedDataDelegate;
 
+/// Name for all implementation errors regarding the plist-based configuration of this class.
+extern NSString * const JSInvalidConfigurationException;
+
 @interface JSDecoupledAppDelegate : UIResponder <UIApplicationDelegate>
 
 /**

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -298,8 +298,9 @@ static id NewDelegateForProtocolFromDictionary(Protocol *protocol, NSDictionary 
 
 	Class delegateClass = NSClassFromString(className);
 	if (!class_conformsToProtocol(delegateClass, protocol))
-		[NSException raise:NSInternalInconsistencyException format:@"Delegate class named “%@” does not conform to protocol %@!", delegateClass, protocolName];
+		[NSException raise:JSInvalidConfigurationException format:@"Delegate class named “%@” does not conform to protocol %@!", delegateClass, protocolName];
 
 	return [delegateClass new];
 }
 
+NSString * const JSInvalidConfigurationException = @"JSInvalidConfigurationException";

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -77,6 +77,8 @@ static NSArray *JSApplicationDelegateSubprotocols()
     return protocols;
 }
 
+static id NewDelegateForProtocolFromDictionary(Protocol *protocol, NSDictionary *dictionary) NS_RETURNS_RETAINED;
+
 @implementation JSDecoupledAppDelegate
 
 #pragma mark - Method Proxying
@@ -286,3 +288,18 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
 }
 
 @end
+
+static id NewDelegateForProtocolFromDictionary(Protocol *protocol, NSDictionary *dictionary)
+{
+	NSString *protocolName = NSStringFromProtocol(protocol);
+	NSString *className = [dictionary objectForKey:protocolName];
+	if (!className)
+		return nil;
+
+	Class delegateClass = NSClassFromString(className);
+	if (!class_conformsToProtocol(delegateClass, protocol))
+		[NSException raise:NSInternalInconsistencyException format:@"Delegate class named “%@” does not conform to protocol %@!", delegateClass, protocolName];
+
+	return [delegateClass new];
+}
+

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -152,6 +152,32 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
     }
 }
 
+#define _protocolInstance(protocolName) \
+	NewDelegateForProtocolFromDictionary(@protocol(protocolName), classNamesByProtocolNames)
+- (id)initWithDelegateMap:(NSDictionary *)classNamesByProtocolNames
+{
+	NSArray *validKeys = JSApplicationDelegateSubprotocols();
+	[classNamesByProtocolNames enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+		if (![key isKindOfClass:[NSString class]]
+			|| ![value isKindOfClass:[NSString class]])
+			[NSException raise:JSInvalidConfigurationException format:@"The key/value pairs must be pairs of strings! %p, howver contained the pair %@, %@.", classNamesByProtocolNames, key, value];
+
+		if (![validKeys containsObject:key])
+			[NSException raise:JSInvalidConfigurationException format:@"The key “%@” is invalid!\nThe allowed values are: “%@”", key, [validKeys componentsJoinedByString:@"”, “"]];
+	}];
+	if (!(self = [super init])) return nil;
+
+	_appStateDelegate = _protocolInstance(JSApplicationStateDelegate);
+	_appDefaultOrientationDelegate = _protocolInstance(JSApplicationDefaultOrientationDelegate);
+	_backgroundFetchDelegate = _protocolInstance(JSApplicationBackgroundFetchDelegate);
+	_remoteNotificationsDelegate = _protocolInstance(JSApplicationRemoteNotificationsDelegate);
+	_localNotificationsDelegate = _protocolInstance(JSApplicationLocalNotificationsDelegate);
+	_stateRestorationDelegate = _protocolInstance(JSApplicationStateRestorationDelegate);
+	_protectedDataDelegate = _protocolInstance(JSApplicationProtectedDataDelegate);
+
+	return self;
+}
+
 #pragma mark - JSApplicationStateDelegate
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -148,7 +148,16 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
     }
     else
     {
-        return [super init];
+		NSString *fileName = @"ApplicationDelegateConfiguration";
+		NSURL *plistURL = [[NSBundle mainBundle] URLForResource:fileName withExtension:@"plist"];
+		if (!plistURL)
+			[NSException raise:JSInvalidConfigurationException format:@"Main bundle must contain a plist named “%@”!", fileName];
+
+		NSDictionary *classNamesByProtocolNames = [NSDictionary dictionaryWithContentsOfURL:plistURL];
+		if (!classNamesByProtocolNames)
+			[NSException raise:JSInvalidConfigurationException format:@"Plist “%@” did not contain a valid configuration dictionary!", fileName];
+
+        return [self initWithDelegateMap:classNamesByProtocolNames];
     }
 }
 

--- a/JSDecoupledAppDelegate_SampleApp.xcodeproj/project.pbxproj
+++ b/JSDecoupledAppDelegate_SampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		74C6AA06186FA3350033CBED /* ApplicationDelegateConfiguration.plist in Resources */ = {isa = PBXBuildFile; fileRef = 74C6AA05186FA3350033CBED /* ApplicationDelegateConfiguration.plist */; };
 		D054E97617E7A356007D9673 /* JSDecoupledAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D054E97517E7A356007D9673 /* JSDecoupledAppDelegate.m */; };
 		D0C415E217DEDA75003F9C6E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0C415E117DEDA75003F9C6E /* Foundation.framework */; };
 		D0C415E417DEDA75003F9C6E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0C415E317DEDA75003F9C6E /* CoreGraphics.framework */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		74C6AA05186FA3350033CBED /* ApplicationDelegateConfiguration.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ApplicationDelegateConfiguration.plist; sourceTree = "<group>"; };
 		D054E97417E7A356007D9673 /* JSDecoupledAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSDecoupledAppDelegate.h; path = JSDecoupledAppDelegate/JSDecoupledAppDelegate.h; sourceTree = SOURCE_ROOT; };
 		D054E97517E7A356007D9673 /* JSDecoupledAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JSDecoupledAppDelegate.m; path = JSDecoupledAppDelegate/JSDecoupledAppDelegate.m; sourceTree = SOURCE_ROOT; };
 		D0C415DE17DEDA75003F9C6E /* JSDecoupledAppDelegate_SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JSDecoupledAppDelegate_SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -127,6 +129,7 @@
 				D0C415EA17DEDA75003F9C6E /* InfoPlist.strings */,
 				D0C415ED17DEDA75003F9C6E /* main.m */,
 				D0C415EF17DEDA75003F9C6E /* JSDecoupledAppDelegate_SampleApp-Prefix.pch */,
+				74C6AA05186FA3350033CBED /* ApplicationDelegateConfiguration.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -226,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0C415EC17DEDA75003F9C6E /* InfoPlist.strings in Resources */,
+				74C6AA06186FA3350033CBED /* ApplicationDelegateConfiguration.plist in Resources */,
 				D0C415F417DEDA75003F9C6E /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/JSDecoupledAppDelegate_SampleApp/ApplicationDelegateConfiguration.plist
+++ b/JSDecoupledAppDelegate_SampleApp/ApplicationDelegateConfiguration.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/JSDecoupledAppDelegate_SampleApp/ApplicationDelegateConfiguration.plist
+++ b/JSDecoupledAppDelegate_SampleApp/ApplicationDelegateConfiguration.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>JSApplicationStateDelegate</key>
+	<string>JSApplicationStateDelegate</string>
+</dict>
 </plist>

--- a/JSDecoupledAppDelegate_SampleApp/JSApplicationStateDelegate.m
+++ b/JSDecoupledAppDelegate_SampleApp/JSApplicationStateDelegate.m
@@ -10,11 +10,6 @@
 
 @implementation JSApplicationStateDelegate
 
-+ (void)load
-{
-    [JSDecoupledAppDelegate sharedAppDelegate].appStateDelegate = [[self alloc] init];
-}
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     return YES;


### PR DESCRIPTION
This series of commits implements setup of the individual delegates using one common plist. They follow the idea that each step in this setup is necessary, and misconfiguration is an implementation error. Therefore, invalid contents of that file (including a missing one) raise exceptions in order to have some reliable checks on the API contracts involved.
## Known Limitations

The implementation is pretty naive, and will create a new instance for each of the specific delegates that are configured in the plist. This means that you cannot have one class conform to more than one of these protocols, **and** be assured that a common instance is used for those tasks.
Then again, that would be somewhat counter to what this whole system wants to achieve in the first place.
## Stuff that’s Missing

Initially, I forgot to update the Readme file(s), and when I became aware of that, I was too lazy to do so.
