### PR TITLE
Leverage Message Forwarding Fast-Path for Delegation

### DIFF
--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -9,73 +9,8 @@
 
 #import <objc/runtime.h>
 
-static NSSet *_JSSelectorsInProtocol(Protocol *protocol, BOOL required)
-{
-    NSUInteger methodCount;
-    struct objc_method_description *methods = protocol_copyMethodDescriptionList(protocol, required, YES, &methodCount);
-
-    NSMutableSet *selectorsInProtocol = [NSMutableSet setWithCapacity:methodCount];
-    for (NSUInteger i = 0; i < methodCount; i++)
-    {
-        [selectorsInProtocol addObject:NSStringFromSelector(methods[i].name)];
-    }
-
-    free(methods);
-
-    return selectorsInProtocol;
-}
-
-static NSSet *JSSelectorListInProtocol(Protocol *protocol)
-{
-    NSMutableSet *selectors = [NSMutableSet set];
-
-    [selectors unionSet:_JSSelectorsInProtocol(protocol, YES)];
-    [selectors unionSet:_JSSelectorsInProtocol(protocol, NO)];
-
-    return selectors;
-}
-
-static NSArray *JSApplicationDelegateProperties()
-{
-    static NSArray *properties = nil;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        properties = @[
-                       NSStringFromSelector(@selector(appStateDelegate)),
-                       NSStringFromSelector(@selector(appDefaultOrientationDelegate)),
-                       NSStringFromSelector(@selector(backgroundFetchDelegate)),
-                       NSStringFromSelector(@selector(remoteNotificationsDelegate)),
-                       NSStringFromSelector(@selector(localNotificationsDelegate)),
-                       NSStringFromSelector(@selector(stateRestorationDelegate)),
-                       NSStringFromSelector(@selector(URLResourceOpeningDelegate)),
-                       NSStringFromSelector(@selector(protectedDataDelegate)),
-                       ];
-    });
-
-    return properties;
-}
-
-static NSArray *JSApplicationDelegateSubprotocols()
-{
-    static NSArray *protocols = nil;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        protocols = @[
-                      NSStringFromProtocol(@protocol(JSApplicationStateDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationDefaultOrientationDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationBackgroundFetchDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationRemoteNotificationsDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationLocalNotificationsDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationStateRestorationDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationURLResourceOpeningDelegate)),
-                      NSStringFromProtocol(@protocol(JSApplicationProtectedDataDelegate))
-                      ];
-    });
-
-    return protocols;
-}
+static void JSRemoveAllOccurrencesOfObjectFromDictionaryRef(id object, CFMutableDictionaryRef dictionary);
+static void JSAddMethodsFromProtocolImplementedByObjectToDictionaryRef(Protocol *protocol, id object, CFMutableDictionaryRef dictionary);
 
 @implementation JSDecoupledAppDelegate
 {
@@ -86,40 +21,18 @@ static NSArray *JSApplicationDelegateSubprotocols()
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
-    NSArray *delegateProperties = JSApplicationDelegateProperties();
+	if ([self forwardingTargetForSelector:aSelector]) return YES;
 
-    // 1. Get the protocol that the method corresponds to
-    __block BOOL protocolFound = NO;
-    __block BOOL delegateRespondsToSelector = NO;
+	return [super respondsToSelector:aSelector];
+}
 
-    [JSApplicationDelegateSubprotocols() enumerateObjectsUsingBlock:^(NSString *protocolName, NSUInteger idx, BOOL *stop) {
-        NSSet *protocolMethods = JSSelectorListInProtocol(NSProtocolFromString(protocolName));
+- (id)forwardingTargetForSelector:(SEL)selector
+{
+	id target = (id)CFDictionaryGetValue(_delegatesBySelector, selector);
+	if (target)
+		return target;
 
-        const BOOL methodCorrespondsToThisProtocol = [protocolMethods containsObject:NSStringFromSelector(aSelector)];
-
-        if (methodCorrespondsToThisProtocol)
-        {
-            protocolFound = YES;
-
-            // 2. Get the property for that protocol
-            id delegateObjectForProtocol = [self valueForKey:delegateProperties[idx]];
-
-            delegateRespondsToSelector = [delegateObjectForProtocol respondsToSelector:aSelector];
-
-            *stop = YES;
-        }
-    }];
-
-    if (protocolFound)
-    {
-        // 3. Return whether that delegate responds to this method
-        return delegateRespondsToSelector;
-    }
-    else
-    {
-        // 4. Doesn't correspond to any? Then just return whether we respond to it:
-        return [super respondsToSelector:aSelector];
-    }
+	return [super forwardingTargetForSelector:selector];
 }
 
 #pragma mark - Singleton
@@ -158,140 +71,12 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
     }
 }
 
-#pragma mark - JSApplicationStateDelegate
-
-- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (void)dealloc
 {
-    return [self.appStateDelegate application:application willFinishLaunchingWithOptions:launchOptions];
+	if (_delegatesBySelector)
+		CFRelease(_delegatesBySelector);
 }
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-    return [self.appStateDelegate application:application didFinishLaunchingWithOptions:launchOptions];
-}
-
-- (void)applicationDidFinishLaunching:(UIApplication *)application
-{
-    [self.appStateDelegate applicationDidFinishLaunching:application];
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    [self.appStateDelegate applicationWillResignActive:application];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    [self.appStateDelegate applicationDidBecomeActive:application];
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    [self.appStateDelegate applicationDidEnterBackground:application];
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    [self.appStateDelegate applicationWillEnterForeground:application];
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    [self.appStateDelegate applicationWillTerminate:application];
-}
-
-#pragma mark - JSApplicationDefaultOrientationDelegate
-
-- (NSUInteger)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window
-{
-    return [self.appDefaultOrientationDelegate application:application supportedInterfaceOrientationsForWindow:window];
-}
-
-#pragma mark - JSApplicationBackgroundFetchDelegate
-
-#if JSIOS7SDK
-- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
-{
-    [self.backgroundFetchDelegate application:application performFetchWithCompletionHandler:completionHandler];
-}
-#endif
-
-#pragma mark - JSApplicationRemoteNotificationsDelegate
-
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
-{
-    [self.remoteNotificationsDelegate application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-}
-
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
-{
-    [self.remoteNotificationsDelegate application:application didFailToRegisterForRemoteNotificationsWithError:error];
-}
-
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
-{
-    [self.remoteNotificationsDelegate application:application didReceiveRemoteNotification:userInfo];
-}
-
-#if JSIOS7SDK
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
-{
-    [self.remoteNotificationsDelegate application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-}
-#endif
-
-#pragma mark - JSApplicationLocalNotificationsDelegate
-
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
-{
-    [self.localNotificationsDelegate application:application didReceiveLocalNotification:notification];
-}
-
-#pragma mark - JSApplicationStateRestorationDelegate
-
-- (UIViewController *)application:(UIApplication *)application viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
-{
-    return [self.stateRestorationDelegate application:application viewControllerWithRestorationIdentifierPath:identifierComponents coder:coder];
-}
-
-- (BOOL)application:(UIApplication *)application shouldSaveApplicationState:(NSCoder *)coder
-{
-    return [self.stateRestorationDelegate application:application shouldSaveApplicationState:coder];
-}
-
-- (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
-{
-    return [self.stateRestorationDelegate application:application shouldRestoreApplicationState:coder];
-}
-
-- (void)application:(UIApplication *)application willEncodeRestorableStateWithCoder:(NSCoder *)coder
-{
-    [self.stateRestorationDelegate application:application willEncodeRestorableStateWithCoder:coder];
-}
-
-- (void)application:(UIApplication *)application didDecodeRestorableStateWithCoder:(NSCoder *)coder
-{
-    [self.stateRestorationDelegate application:application didDecodeRestorableStateWithCoder:coder];
-}
-
-#pragma mark - JSApplicationURLResourceOpeningDelegate
-
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
-{
-    return [self.URLResourceOpeningDelegate application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
-}
-
-#pragma mark - JSApplicationProtectedDataDelegate
-
-- (void)applicationProtectedDataWillBecomeUnavailable:(UIApplication *)application
-{
-    [self.protectedDataDelegate applicationProtectedDataWillBecomeUnavailable:application];
-}
-
-- (void)applicationProtectedDataDidBecomeAvailable:(UIApplication *)application
-{
-    [self.protectedDataDelegate applicationProtectedDataDidBecomeAvailable:application];
-}
 
 @end
 

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -77,6 +77,53 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
 		CFRelease(_delegatesBySelector);
 }
 
+#pragma mark - Setters
+
+#define UpdatePropertyAndMapForProtocol(propertyName, protocolName) \
+if (propertyName == _ ##propertyName) return; \
+JSRemoveAllOccurrencesOfObjectFromDictionaryRef(_ ##propertyName, _delegatesBySelector); \
+_ ##propertyName = propertyName; \
+JSAddMethodsFromProtocolImplementedByObjectToDictionaryRef(@protocol(protocolName), propertyName, _delegatesBySelector)
+
+- (void)setAppStateDelegate:(id<JSApplicationStateDelegate>)appStateDelegate
+{
+	UpdatePropertyAndMapForProtocol(appStateDelegate, JSApplicationStateDelegate);
+}
+
+- (void)setAppDefaultOrientationDelegate:(id<JSApplicationDefaultOrientationDelegate>)appDefaultOrientationDelegate
+{
+	UpdatePropertyAndMapForProtocol(appDefaultOrientationDelegate, JSApplicationDefaultOrientationDelegate);
+}
+
+- (void)setBackgroundFetchDelegate:(id<JSApplicationBackgroundFetchDelegate>)backgroundFetchDelegate
+{
+	UpdatePropertyAndMapForProtocol(backgroundFetchDelegate, JSApplicationBackgroundFetchDelegate);
+}
+
+- (void)setRemoteNotificationsDelegate:(id<JSApplicationRemoteNotificationsDelegate>)remoteNotificationsDelegate
+{
+	UpdatePropertyAndMapForProtocol(remoteNotificationsDelegate, JSApplicationRemoteNotificationsDelegate);
+}
+
+- (void)setLocalNotificationsDelegate:(id<JSApplicationLocalNotificationsDelegate>)localNotificationsDelegate
+{
+	UpdatePropertyAndMapForProtocol(localNotificationsDelegate, JSApplicationLocalNotificationsDelegate);
+}
+
+- (void)setStateRestorationDelegate:(id<JSApplicationStateRestorationDelegate>)stateRestorationDelegate
+{
+	UpdatePropertyAndMapForProtocol(stateRestorationDelegate, JSApplicationStateRestorationDelegate);
+}
+
+- (void)setURLResourceOpeningDelegate:(id<JSApplicationURLResourceOpeningDelegate>)URLResourceOpeningDelegate
+{
+	UpdatePropertyAndMapForProtocol(URLResourceOpeningDelegate, JSApplicationURLResourceOpeningDelegate);
+}
+
+- (void)setProtectedDataDelegate:(id<JSApplicationProtectedDataDelegate>)protectedDataDelegate
+{
+	UpdatePropertyAndMapForProtocol(protectedDataDelegate, JSApplicationProtectedDataDelegate);
+}
 
 @end
 


### PR DESCRIPTION
These commits migrate manually calling the specific delegates to a generic approach that uses message forwarding, which results in a significant reduction of code.
Another nice side-effect is that whenever new methods are added to UIApplicationDelegate, they only need to be added to the appropriate sub-protocol, once—forwarding then happens automatically, as soon as the concrete delegate implements the new method.
