### PR TITLE
Fix: NSUInteger and unsigned int different size on 64-bit systems.

### DIFF
--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -11,7 +11,7 @@
 
 static NSSet *_JSSelectorsInProtocol(Protocol *protocol, BOOL required)
 {
-    NSUInteger methodCount;
+    unsigned int methodCount;
     struct objc_method_description *methods = protocol_copyMethodDescriptionList(protocol, required, YES, &methodCount);
 
     NSMutableSet *selectorsInProtocol = [NSMutableSet setWithCapacity:methodCount];


### PR DESCRIPTION
On a 64-bit system the value of `methodCount` returned will be something like 4294967296.

If you're lucky you'll get as far as an error message trying to use it. Yes, this is an actual error message!

```
'*** -[__NSPlaceholderSet initWithCapacity:]: capacity (18446744065119617024) is ridiculous'
```
