### PR TITLE
Fix warning about incorrect return type.

### DIFF
--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -204,7 +204,7 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
 
 #pragma mark - JSApplicationDefaultOrientationDelegate
 
-- (NSUInteger)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window
 {
     return [self.appDefaultOrientationDelegate application:application supportedInterfaceOrientationsForWindow:window];
 }


### PR DESCRIPTION
Update method signature to fix warning about method signature having the wrong return type, i.e replace NSUInteger with UIInterfaceOrientationMask.