### PR TITLE
properly deprecate -application:openURL:sourceApplication:annotation for iOS 9 and up

### DIFF
--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
@@ -145,8 +145,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol JSApplicationURLResourceOpeningDelegate <NSObject>
 
-@optional
-
 #if JSIOS8SDK
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
 #endif

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
@@ -145,10 +145,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol JSApplicationURLResourceOpeningDelegate <NSObject>
 
-
-#if IOS9
+#if JSIOS9SDK
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options;
-#elif IOS8
+#elif JSIOS8SDK
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
 #else
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url;

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
@@ -145,7 +145,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol JSApplicationURLResourceOpeningDelegate <NSObject>
 
+@optional
+
+#if JSIOS8SDK
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
+#endif
+
 #if JSIOS9SDK
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options NS_AVAILABLE_IOS(9_0);
 #endif

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.h
@@ -145,12 +145,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol JSApplicationURLResourceOpeningDelegate <NSObject>
 
-#if JSIOS8SDK
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
-#endif
 
-#if JSIOS9SDK
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options NS_AVAILABLE_IOS(9_0);
+#if IOS9
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options;
+#elif IOS8
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(id)annotation;
+#else
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url;
 #endif
 
 @end

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -315,15 +315,20 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
 
 #pragma mark - JSApplicationURLResourceOpeningDelegate
 
+#if IOS9
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options
+{
+    return [self.URLResourceOpeningDelegate application:app openURL:url options:options];
+}
+#elif IOS8
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
 {
     return [self.URLResourceOpeningDelegate application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
 }
-
-#if JSIOS9SDK
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options
+#else
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url
 {
-    return [self.URLResourceOpeningDelegate application:app openURL:url options:options];
+    return [self.URLResourceOpeningDelegate application:application handleOpenURL:url];
 }
 #endif
 

--- a/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
+++ b/JSDecoupledAppDelegate/JSDecoupledAppDelegate.m
@@ -315,12 +315,12 @@ static JSDecoupledAppDelegate *sharedAppDelegate = nil;
 
 #pragma mark - JSApplicationURLResourceOpeningDelegate
 
-#if IOS9
+#if JSIOS9SDK
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString*, id> *)options
 {
     return [self.URLResourceOpeningDelegate application:app openURL:url options:options];
 }
-#elif IOS8
+#elif JSIOS8SDK
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
 {
     return [self.URLResourceOpeningDelegate application:application openURL:url sourceApplication:sourceApplication annotation:annotation];


### PR DESCRIPTION
`-application:openURL:sourceApplication:annotation:(id)annotation;` was deprecated in iOS 9.

When updating the `JSApplicationURLResourceOpeningDelegate` for iOS 9 last year, I didn't wrap the deprecated method in an `#if JSIOS8SDK` statement when adding the new `- application:openURL:options:options` replacement.

This was causing a compiler warning once I dropped iOS 8 support.

I've added the `#if JSIOS8SDK` statement and also marked the entire protocol as `@optional`. Let me know if there is a preferred technique for deprecating methods and I'll update this PR.

